### PR TITLE
Reset number of workers to spawn after pool has been resized

### DIFF
--- a/optuna_distributed/managers/local.py
+++ b/optuna_distributed/managers/local.py
@@ -85,6 +85,7 @@ class LocalOptimizationManager(OptimizationManager):
         if self._workers_to_spawn > 0:
             self.create_futures(event_loop.study, event_loop.objective)
             self._trials_remaining -= self._workers_to_spawn
+            self._workers_to_spawn = 0
 
     def get_connection(self, trial_id: int) -> "IPCPrimitive":
         return Pipe(self._pool[trial_id])


### PR DESCRIPTION
This prevents situation where the pool is resized multiple times for the same event loop pass due to a race condition, eventually leading us to miss stop optimization signals with `multiprocessing` based manager. Closes #5.