### PR TITLE
Simplify naming scheme of distributed study factory function

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ def objective(trial):
 if __name__ == "__main__":
     # client = Client("<your.cluster.scheduler.address>")  # For distributed optimization.
     client = Client()  # For local asynchronous optimization.
-    study = optuna_distributed.from_optuna_study(optuna.create_study(), client=client)
+    study = optuna_distributed.from_study(optuna.create_study(), client=client)
     study.optimize(objective, n_trials=10)
     print(study.best_value)
 ```

--- a/examples/quadratic_simple.py
+++ b/examples/quadratic_simple.py
@@ -37,7 +37,7 @@ if __name__ == "__main__":
 
     # Optuna-distributed just wraps standard Optuna study. The resulting object behaves
     # just like regular study, but optimization process is asynchronous.
-    study = optuna_distributed.from_optuna_study(optuna.create_study(), client=client)
+    study = optuna_distributed.from_study(optuna.create_study(), client=client)
 
     # And let's continue with original Optuna example from here.
     # Let us minimize the objective function above.

--- a/examples/simple_pruning.py
+++ b/examples/simple_pruning.py
@@ -48,7 +48,7 @@ def objective(trial):
 if __name__ == "__main__":
     # Optuna-distributed just wraps standard Optuna study. The resulting object behaves
     # just like regular study, but optimization process is asynchronous.
-    study = optuna_distributed.from_optuna_study(
+    study = optuna_distributed.from_study(
         optuna.create_study(direction="maximize"), client=Client()
     )
     study.optimize(objective, n_trials=100)

--- a/examples/simple_storages.py
+++ b/examples/simple_storages.py
@@ -40,7 +40,7 @@ if __name__ == "__main__":
 
     # Optuna-distributed just wraps standard Optuna study. The resulting object behaves
     # just like regular study, but optimization process is asynchronous.
-    study = optuna_distributed.from_optuna_study(
+    study = optuna_distributed.from_study(
         optuna.create_study(storage=storage, sampler=sampler), client=client
     )
 

--- a/optuna_distributed/__init__.py
+++ b/optuna_distributed/__init__.py
@@ -1,5 +1,5 @@
-from optuna_distributed.study import from_optuna_study
+from optuna_distributed.study import from_study
 
 
 __version__ = "0.1.0"
-__all__ = ["from_optuna_study"]
+__all__ = ["from_study"]

--- a/optuna_distributed/study.py
+++ b/optuna_distributed/study.py
@@ -375,7 +375,7 @@ def _wrap_objective(func: ObjectiveFuncType) -> DistributableFuncType:
     return _objective_wrapper
 
 
-def from_optuna_study(study: Study, client: Optional[Client] = None) -> DistributedStudy:
+def from_study(study: Study, client: Optional[Client] = None) -> DistributedStudy:
     """Takes regular Optuna study and extends it to :class:`~optuna_distributed.DistributedStudy`.
 
     This creates an object which behaves like regular Optuna study, except trials


### PR DESCRIPTION
This PR drops repeated usage of `optuna`, leaving only short `from_study`.