### PR TITLE
Wrap objective function only when it's needed

### DIFF
--- a/optuna_distributed/eventloop.py
+++ b/optuna_distributed/eventloop.py
@@ -12,7 +12,7 @@ from optuna.study import Study
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 
-from optuna_distributed.managers import DistributableFuncType
+from optuna_distributed.managers import ObjectiveFuncType
 from optuna_distributed.managers import OptimizationManager
 
 
@@ -37,7 +37,7 @@ class EventLoop:
         self,
         study: Study,
         manager: OptimizationManager,
-        objective: DistributableFuncType,
+        objective: ObjectiveFuncType,
     ) -> None:
         self.study = study
         self.manager = manager

--- a/optuna_distributed/managers/base.py
+++ b/optuna_distributed/managers/base.py
@@ -30,28 +30,16 @@ class OptimizationManager(ABC):
     """
 
     @abc.abstractmethod
-    def provide_distributable(self, func: ObjectiveFuncType) -> DistributableFuncType:
-        """Provides a wrapper to objective function that can be distributed among workers.
-
-        Args:
-            func:
-                User defined callable that implements objective function. Must be
-                serializable and in distributed mode can only use resources available
-                to all workers in cluster.
-        """
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def create_futures(
-        self, study: "Study", objective: Callable[["DistributedTrial"], None]
-    ) -> None:
+    def create_futures(self, study: "Study", objective: ObjectiveFuncType) -> None:
         """Spawns a set of workers to run objective function.
 
         Args:
             study:
                 An instance of Optuna study.
             objective:
-                Objective function to run on worker.
+                User defined callable that implements objective function. Must be
+                serializable and in distributed mode can only use resources available
+                to all workers in cluster.
         """
         raise NotImplementedError
 

--- a/optuna_distributed/managers/distributed.py
+++ b/optuna_distributed/managers/distributed.py
@@ -1,6 +1,5 @@
 import asyncio
 import sys
-from typing import Callable
 from typing import Dict
 from typing import Generator
 from typing import List
@@ -19,8 +18,6 @@ from optuna_distributed.messages import CompletedMessage
 from optuna_distributed.messages import FailedMessage
 from optuna_distributed.messages import HeartbeatMessage
 from optuna_distributed.messages import PrunedMessage
-from optuna_distributed.messages import RepeatedTrialMessage
-from optuna_distributed.messages import ResponseMessage
 from optuna_distributed.trial import DistributedTrial
 
 
@@ -77,17 +74,13 @@ class DistributedOptimizationManager(OptimizationManager):
         self._private_channels[trial_id] = private_channel
         return Queue(self._public_channel, private_channel)
 
-    def provide_distributable(self, func: ObjectiveFuncType) -> DistributableFuncType:
-        return _distributable(func)
-
-    def create_futures(
-        self, study: "Study", objective: Callable[[DistributedTrial], None]
-    ) -> None:
+    def create_futures(self, study: "Study", objective: ObjectiveFuncType) -> None:
         # HACK: It's kinda naughty to access _trial_id, but this is gonna make
         # our lifes much easier in messaging system.
+        distributable = _distributable(objective)
         trial_ids = [study.ask()._trial_id for _ in range(self._n_trials)]
         trials = [DistributedTrial(id, self._assign_private_channel(id)) for id in trial_ids]
-        self._futures = self._client.map(objective, trials, pure=False)
+        self._futures = self._client.map(distributable, trials, pure=False)
         for future in self._futures:
             future.add_done_callback(self._ensure_safe_exit)
 

--- a/optuna_distributed/managers/distributed.py
+++ b/optuna_distributed/managers/distributed.py
@@ -127,13 +127,8 @@ class DistributedOptimizationManager(OptimizationManager):
 
 def _distributable(func: ObjectiveFuncType) -> DistributableFuncType:
     def _wrapper(trial: DistributedTrial) -> None:
-        trial.connection.put(RepeatedTrialMessage(trial.trial_id))
-        is_repeated = trial.connection.get()
-        assert isinstance(is_repeated, ResponseMessage)
+        # FIXME: Re-introduce task deduplication.
         message: Message
-        if is_repeated.data:
-            return
-
         try:
             value_or_values = func(trial)
             message = CompletedMessage(trial.trial_id, value_or_values)

--- a/optuna_distributed/study.py
+++ b/optuna_distributed/study.py
@@ -177,8 +177,7 @@ class DistributedStudy:
         )
 
         try:
-            distributable = manager.provide_distributable(func)
-            event_loop = EventLoop(self._study, manager, distributable)
+            event_loop = EventLoop(self._study, manager, objective=func)
             event_loop.run(n_trials, timeout, catch, callbacks, show_progress_bar)
 
         except KeyboardInterrupt:

--- a/tests/test_eventloop.py
+++ b/tests/test_eventloop.py
@@ -1,18 +1,14 @@
-import sys
-
 import optuna
 import pytest
 
 from optuna_distributed.eventloop import EventLoop
 from optuna_distributed.managers import LocalOptimizationManager
-from optuna_distributed.messages import FailedMessage
 from optuna_distributed.trial import DistributedTrial
 
 
 def test_raises_on_trial_exception() -> None:
-    def _objective(trial: DistributedTrial) -> None:
-        exception = ValueError()
-        trial.connection.put(FailedMessage(trial.trial_id, exception, exc_info=sys.exc_info()))
+    def _objective(trial: DistributedTrial) -> float:
+        raise ValueError()
 
     n_trials = 5
     study = optuna.create_study()
@@ -23,9 +19,8 @@ def test_raises_on_trial_exception() -> None:
 
 
 def test_catches_on_trial_exception() -> None:
-    def _objective(trial: DistributedTrial) -> None:
-        exception = ValueError()
-        trial.connection.put(FailedMessage(trial.trial_id, exception, exc_info=sys.exc_info()))
+    def _objective(trial: DistributedTrial) -> float:
+        raise ValueError()
 
     n_trials = 5
     study = optuna.create_study()

--- a/tests/test_managers.py
+++ b/tests/test_managers.py
@@ -3,11 +3,12 @@ import multiprocessing
 import time
 
 from dask.distributed import Client
+from dask.distributed import wait
 import optuna
 
-from optuna_distributed.managers import DistributableFuncType
 from optuna_distributed.managers import DistributedOptimizationManager
 from optuna_distributed.managers import LocalOptimizationManager
+from optuna_distributed.managers import ObjectiveFuncType
 from optuna_distributed.messages import CompletedMessage
 from optuna_distributed.messages import HeartbeatMessage
 from optuna_distributed.messages import ResponseMessage
@@ -15,24 +16,22 @@ from optuna_distributed.trial import DistributedTrial
 
 
 def test_distributed_get_message(client: Client) -> None:
-    def _objective(trial: DistributedTrial) -> None:
-        trial.connection.put(ResponseMessage(0, data=None))
-
     n_trials = 5
     study = optuna.create_study()
     manager = DistributedOptimizationManager(client, n_trials)
-    manager.create_futures(study, _objective)
+    manager.create_futures(study, lambda trial: 0.0)
     completed = 0
     for message in manager.get_message():
-        assert isinstance(message, ResponseMessage)
+        assert isinstance(message, CompletedMessage)
         completed += 1
         if completed == n_trials:
             break
 
 
 def test_distributed_heartbeat_on_timeout(client: Client) -> None:
-    def _objective(trial: DistributedTrial) -> None:
-        ...
+    def _objective(trial: DistributedTrial) -> float:
+        time.sleep(2.0)
+        return 0.0
 
     study = optuna.create_study()
     manager = DistributedOptimizationManager(client, n_trials=1, heartbeat_interval=1)
@@ -43,51 +42,31 @@ def test_distributed_heartbeat_on_timeout(client: Client) -> None:
         assert 0.8 < time.time() - start < 1.2
         break
 
+    wait(manager._futures)
+
 
 def test_distributed_should_end_optimization(client: Client) -> None:
-    def _objective(trial: DistributedTrial) -> None:
-        # Non-closing message first.
-        trial.connection.put(ResponseMessage(trial.trial_id, data=None))
-        # Closing message follows.
-        trial.connection.put(CompletedMessage(trial.trial_id, 0.0))
-
     n_trials = 5
     study = optuna.create_study()
     manager = DistributedOptimizationManager(client, n_trials)
-    manager.create_futures(study, _objective)
-    messages_recieved = 0
+    manager.create_futures(study, lambda trial: 0.0)
+    closing_messages_recieved = 0
     for message in manager.get_message():
-        messages_recieved += 1
         assert not isinstance(message, HeartbeatMessage)
-        if isinstance(message, CompletedMessage):
-            manager.register_trial_exit(message._trial_id)
+        if message.closing:
+            closing_messages_recieved += 1
+            manager.register_trial_exit(message._trial_id)  # type: ignore
 
         if manager.should_end_optimization():
             break
 
-    assert messages_recieved == n_trials * 2
-
-
-def test_distributed_registers_future_failure(client: Client) -> None:
-    def _objective(trial: DistributedTrial) -> None:
-        # Simulate ungraceful faliure.
-        assert False
-
-    study = optuna.create_study()
-    manager = DistributedOptimizationManager(client, n_trials=5)
-    manager.create_futures(study, _objective)
-    messages = []
-    for message in manager.get_message():
-        messages.append(message)
-        if manager.should_end_optimization():
-            break
-
-    assert all(isinstance(msg, HeartbeatMessage) for msg in messages)
+    assert closing_messages_recieved == n_trials
 
 
 def test_distributed_stops_optimziation(client: Client) -> None:
-    def _objective(trial: DistributedTrial) -> None:
+    def _objective(trial: DistributedTrial) -> float:
         time.sleep(2.0)
+        return 0.0
 
     study = optuna.create_study()
     manager = DistributedOptimizationManager(client, n_trials=5)
@@ -98,11 +77,12 @@ def test_distributed_stops_optimziation(client: Client) -> None:
 
 
 def test_distributed_connection_management(client: Client) -> None:
-    def _objective(trial: DistributedTrial) -> None:
+    def _objective(trial: DistributedTrial) -> float:
         requested = trial.connection.get()
         assert isinstance(requested, ResponseMessage)
         data = {"requested": requested.data, "actual": trial.trial_id}
         trial.connection.put(ResponseMessage(trial.trial_id, data))
+        return 0.0
 
     n_trials = 5
     study = optuna.create_study()
@@ -112,18 +92,19 @@ def test_distributed_connection_management(client: Client) -> None:
         connection = manager.get_connection(trial._trial_id)
         connection.put(ResponseMessage(0, data=trial._trial_id))
 
-    recieved = 0
     for message in manager.get_message():
-        assert isinstance(message, ResponseMessage)
-        assert message.data["requested"] == message.data["actual"]
-        recieved += 1
-        if recieved == n_trials:
+        if message.closing:
+            manager.register_trial_exit(message._trial_id)  # type: ignore
+        if isinstance(message, ResponseMessage):
+            assert message.data["requested"] == message.data["actual"]
+        if manager.should_end_optimization():
             break
 
 
 def test_local_get_message() -> None:
-    def _objective(trial: DistributedTrial) -> None:
+    def _objective(trial: DistributedTrial) -> float:
         trial.connection.put(ResponseMessage(0, data=None))
+        return 0.0
 
     n_trials = 1
     study = optuna.create_study()
@@ -138,34 +119,29 @@ def test_local_get_message() -> None:
 
 
 def test_local_should_end_optimization() -> None:
-    def _objective(trial: DistributedTrial) -> None:
-        # Non-closing message first.
-        trial.connection.put(ResponseMessage(trial.trial_id, data=None))
-        # Closing message follows.
-        trial.connection.put(CompletedMessage(trial.trial_id, 0.0))
-
     n_trials = 1
     study = optuna.create_study()
     manager = LocalOptimizationManager(n_trials, n_jobs=1)
-    manager.create_futures(study, _objective)
-    messages_recieved = 0
+    manager.create_futures(study, lambda trial: 0.0)
+    closing_messages_recieved = 0
     for message in manager.get_message():
-        messages_recieved += 1
-        if isinstance(message, CompletedMessage):
-            manager.register_trial_exit(message._trial_id)
+        if message.closing:
+            closing_messages_recieved += 1
+            manager.register_trial_exit(message._trial_id)  # type: ignore
 
         if manager.should_end_optimization():
             break
 
-    assert messages_recieved == n_trials * 2 + 1
+    assert closing_messages_recieved == n_trials
 
 
 def test_local_connection_management() -> None:
-    def _objective(trial: DistributedTrial) -> None:
+    def _objective(trial: DistributedTrial) -> float:
         requested = trial.connection.get()
         assert isinstance(requested, ResponseMessage)
         data = {"requested": requested.data, "actual": trial.trial_id}
         trial.connection.put(ResponseMessage(trial.trial_id, data))
+        return 0.0
 
     n_trials = 1
     study = optuna.create_study()
@@ -185,13 +161,13 @@ def test_local_connection_management() -> None:
 
 
 def test_local_worker_pool_management() -> None:
-    def _objective(trial: DistributedTrial) -> None:
-        trial.connection.put(CompletedMessage(trial.trial_id, value_or_values=0.0))
+    def _objective(trial: DistributedTrial) -> float:
+        return 0.0
 
     @dataclass
     class _MockEventLoop:
         study: optuna.Study
-        objective: DistributableFuncType
+        objective: ObjectiveFuncType
 
     study = optuna.create_study()
     manager = LocalOptimizationManager(n_trials=10, n_jobs=-1)

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -1,6 +1,5 @@
 import logging
 from typing import Any
-from typing import Callable
 from typing import Generator
 from unittest.mock import MagicMock
 
@@ -15,7 +14,6 @@ import pytest
 
 from optuna_distributed.eventloop import EventLoop
 from optuna_distributed.ipc import IPCPrimitive
-from optuna_distributed.managers import DistributableFuncType
 from optuna_distributed.managers import ObjectiveFuncType
 from optuna_distributed.managers import OptimizationManager
 from optuna_distributed.messages import CompletedMessage
@@ -31,7 +29,6 @@ from optuna_distributed.messages import ShouldPruneMessage
 from optuna_distributed.messages import SuggestMessage
 from optuna_distributed.messages import TrialProperty
 from optuna_distributed.messages import TrialPropertyMessage
-from optuna_distributed.trial import DistributedTrial
 
 
 class MockConnection(IPCPrimitive):
@@ -54,12 +51,7 @@ class MockOptimizationManager(OptimizationManager):
         self.trial_exit_called = False
         self.message_response = None
 
-    def provide_distributable(self, func: ObjectiveFuncType) -> DistributableFuncType:
-        ...
-
-    def create_futures(
-        self, study: "Study", objective: Callable[["DistributedTrial"], None]
-    ) -> None:
+    def create_futures(self, study: "Study", objective: ObjectiveFuncType) -> None:
         ...
 
     def before_message(self, event_loop: "EventLoop") -> None:


### PR DESCRIPTION
This reduces number and complexity of public APIs and makes study and event loop unaware of what's going on in backend specific objective function wrappers.