### PR TITLE
Interrupt long running trials when `stop_optimization` is called

### DIFF
--- a/optuna_distributed/managers/distributed.py
+++ b/optuna_distributed/managers/distributed.py
@@ -151,6 +151,7 @@ class DistributedOptimizationManager(OptimizationManager):
                 # that allows workers to repeat messages to master.
                 # A deduplication algorithm would go here then.
                 yield self._message_queue.get()
+
             except asyncio.TimeoutError:
                 # Pumping event loop with heartbeat messages on timeout
                 # allows us to handle potential problems gracefully

--- a/optuna_distributed/managers/distributed.py
+++ b/optuna_distributed/managers/distributed.py
@@ -217,8 +217,7 @@ def _distributable(func: ObjectiveFuncType, with_supervisor: bool) -> Distributa
             context.trial.connection.put(message)
 
         except WorkerInterrupted:
-            # FIXME remove this dbgln.
-            print(f"Trial {context.trial.trial_id} interrupted.")
+            ...
 
         except Exception as e:
             exc_info = sys.exc_info()

--- a/optuna_distributed/managers/distributed.py
+++ b/optuna_distributed/managers/distributed.py
@@ -183,8 +183,8 @@ class DistributedOptimizationManager(OptimizationManager):
     def stop_optimization(self) -> None:
         # Only want to cleanup cluster that does not belong to us.
         # TODO(xadrianzetx) Notebooks might be a special case (cleanup even with LocalCluster).
+        self._client.cancel(self._futures)
         if self._is_distributed:
-            self._client.cancel(self._futures)
             # Twice the timeout of task connection.
             # This way even tasks waiting for message will have chance to exit.
             self._synchronizer.emit_stop_and_wait(patience=10)

--- a/optuna_distributed/managers/distributed.py
+++ b/optuna_distributed/managers/distributed.py
@@ -107,6 +107,8 @@ class DistributedOptimizationManager(OptimizationManager):
         self._n_trials = n_trials
         self._completed_trials = 0
         self._public_channel = str(uuid.uuid4())
+        self._synchronizer = _StateSynchronizer()
+        self._is_distributed = not isinstance(client.cluster, LocalCluster)
 
         # Manager has write access to its own message queue as a sort of health check.
         # Basically that means we can pump event loop from callbacks running in

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,11 @@
 from dask.distributed import Client
+from dask.distributed import LocalCluster
 import optuna
 import pytest
 
 
-_test_client = Client(n_workers=1, threads_per_worker=1)
+_test_cluster = LocalCluster(n_workers=1, threads_per_worker=1)
+_test_client = Client(_test_cluster.scheduler_address)
 
 
 @pytest.fixture

--- a/tests/test_managers.py
+++ b/tests/test_managers.py
@@ -1,6 +1,6 @@
-import sys
 from dataclasses import dataclass
 import multiprocessing
+import sys
 import time
 
 from dask.distributed import Client

--- a/tests/test_managers.py
+++ b/tests/test_managers.py
@@ -1,3 +1,4 @@
+import sys
 from dataclasses import dataclass
 import multiprocessing
 import time
@@ -67,6 +68,7 @@ def test_distributed_should_end_optimization(client: Client) -> None:
     assert closing_messages_recieved == n_trials
 
 
+@pytest.mark.skipif(sys.version_info < (3, 8), reason="Requires Python 3.8 or higher")
 def test_distributed_stops_optimziation(client: Client) -> None:
     uninterrupted_execution_time = 100
 


### PR DESCRIPTION
Done via supervisor thread raising custom exception in task thread using low-level API. Not perfect as it will not be able interrupt socket/sleeps, but at least we have something :^)

Looks like it requires Python 3.8 and higher to work correctly. No plans to support this functionality in 3.7.

Closes #14 for the time being. 