### PR TITLE
 Interrupt long running trials when `stop_optimization` is called (multiprocessing backend)

### DIFF
--- a/optuna_distributed/managers/local.py
+++ b/optuna_distributed/managers/local.py
@@ -81,7 +81,7 @@ class LocalOptimizationManager(OptimizationManager):
                     self._pool.pop(trial_id)
 
             self._workers_to_spawn = min(self._n_jobs - len(self._pool), self._trials_remaining)
-            if len(messages) > 0:
+            if messages:
                 yield from messages
             else:
                 yield HeartbeatMessage()


### PR DESCRIPTION
This unifies behavior between both multiprocessing and dask backends.