### PR TITLE
Remove `before_message` hook

### DIFF
--- a/optuna_distributed/eventloop.py
+++ b/optuna_distributed/eventloop.py
@@ -61,7 +61,6 @@ class EventLoop:
         self.manager.create_futures(self.study, self.objective)
         for message in self.manager.get_message():
             try:
-                self.manager.before_message(self)
                 message.process(self.study, self.manager)
                 self.manager.after_message(self)
 

--- a/optuna_distributed/managers/base.py
+++ b/optuna_distributed/managers/base.py
@@ -44,18 +44,6 @@ class OptimizationManager(ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def before_message(self, event_loop: "EventLoop") -> None:
-        """A hook allowing to run additional operations before recieved
-        message is processed.
-
-        Args:
-            event_loop:
-                An instance of :class:`~optuna_distributed.eventloop.EventLoop`
-                providing context to study and manager.
-        """
-        raise NotImplementedError
-
-    @abc.abstractmethod
     def get_message(self) -> Generator[Message, None, None]:
         """Fetches incoming messages from workers."""
         raise NotImplementedError

--- a/optuna_distributed/managers/distributed.py
+++ b/optuna_distributed/managers/distributed.py
@@ -152,9 +152,6 @@ class DistributedOptimizationManager(OptimizationManager):
         for future in self._futures:
             future.add_done_callback(self._ensure_safe_exit)
 
-    def before_message(self, event_loop: "EventLoop") -> None:
-        ...
-
     def get_message(self) -> Generator[Message, None, None]:
         while True:
             try:

--- a/optuna_distributed/managers/local.py
+++ b/optuna_distributed/managers/local.py
@@ -65,9 +65,6 @@ class LocalOptimizationManager(OptimizationManager):
             self._pool[trial_id] = master
             worker.close()
 
-    def before_message(self, event_loop: "EventLoop") -> None:
-        ...
-
     def get_message(self) -> Generator[Message, None, None]:
         while True:
             messages: List[Message] = []


### PR DESCRIPTION
Neither optimization manager is using this hook, so for now it can be removed to avoid dead code. The hook can be re-implemented if needed.