### PR TITLE
Allow dask queue to retry fetching a message if timeout was reached

### DIFF
--- a/optuna_distributed/managers/distributed.py
+++ b/optuna_distributed/managers/distributed.py
@@ -124,7 +124,7 @@ class DistributedOptimizationManager(OptimizationManager):
     def _assign_private_channel(self, trial_id: int) -> "Queue":
         private_channel = str(uuid.uuid4())
         self._private_channels[trial_id] = private_channel
-        return Queue(self._public_channel, private_channel, timeout=5)
+        return Queue(self._public_channel, private_channel, max_retries=5)
 
     def _create_trials(self, study: Study) -> List[DistributedTrial]:
         # HACK: It's kinda naughty to access _trial_id, but this is gonna make

--- a/tests/test_eventloop.py
+++ b/tests/test_eventloop.py
@@ -34,7 +34,7 @@ def test_catches_on_trial_exception() -> None:
     )
 
 
-def test_stops_optimization() -> None:
+def test_stops_optimization_after_timeout() -> None:
     uninterrupted_execution_time = 60.0
 
     def _objective(trial: DistributedTrial) -> float:

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -77,7 +77,8 @@ def test_queue_get_delayed_message(client: Client) -> None:
     future = client.submit(_ping_pong, Queue(public, private, max_retries=5))
     master = Queue(private, public)
 
-    # Force worker to retry getting message at least once.
+    # With exponential timeout, attempts are made after 1, 3, 7, 15... seconds.
+    # To ensure at least one retry, message should be delayed between 1 and 3 seconds.
     time.sleep(2.0)
     master.put(ResponseMessage(0, "ping"))
     response = master.get()


### PR DESCRIPTION
After each attempt, timeout is extended exponentially. This allows us to quickly bail if external signal was received (e.g. supervisor raised an exception to interrupt) and still have enough patience for delayed responses from main process.