### PR TITLE
Remove redundant test skip condition

### DIFF
--- a/tests/test_managers.py
+++ b/tests/test_managers.py
@@ -72,7 +72,6 @@ def test_distributed_should_end_optimization(client: Client) -> None:
     assert closing_messages_recieved == n_trials
 
 
-@pytest.mark.skipif(sys.version_info < (3, 8), reason="Requires Python 3.8 or higher")
 def test_distributed_stops_optimziation(client: Client) -> None:
     uninterrupted_execution_time = 100
 


### PR DESCRIPTION
CI no longer runs tests on Python 3.7 anyway.