### PR TITLE
Add `into_study()` convenience method

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,4 @@ But there's more! All of the core Optuna APIs, including [storages, samplers](ht
 * Support for callbacks and Optuna integration modules.
 * Study APIs such as [`study.stop`](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.study.Study.html#optuna.study.Study.stop) can't be called from trial at the moment.
 * Local asynchronous optimization on Windows machines. Distributed mode is still available.
+* Support for [`optuna.terminator`](https://optuna.readthedocs.io/en/stable/reference/terminator.html).

--- a/examples/visualization.py
+++ b/examples/visualization.py
@@ -1,0 +1,18 @@
+import optuna
+
+import optuna_distributed
+
+
+def objective(trial):
+    x = trial.suggest_float("x", -100, 100)
+    y = trial.suggest_categorical("y", [-1, 0, 1])
+    return x**2 + y
+
+
+sampler = optuna.samplers.TPESampler(seed=10)
+distributed_study = optuna_distributed.from_study(optuna.create_study(sampler=sampler))
+distributed_study.optimize(objective, n_trials=30)
+
+# Any plotting function from optuna.visualization module can be used with Optuna-distributed
+# thanks to .into_study() convenience method.
+optuna.visualization.plot_contour(distributed_study.into_study(), params=["x", "y"]).show()

--- a/optuna_distributed/study.py
+++ b/optuna_distributed/study.py
@@ -113,6 +113,10 @@ class DistributedStudy:
         """Return system attributes."""
         return self._study.system_attrs
 
+    def into_study(self) -> Study:
+        """Returns regular Optuna study."""
+        return self._study
+
     def get_trials(
         self, deepcopy: bool = True, states: Optional[Container[TrialState]] = None
     ) -> List[FrozenTrial]:


### PR DESCRIPTION
This enables users to unwrap original Optuna study and use it in places such as plotting functions from `optuna.visualization` module. Closes #80.